### PR TITLE
chore: migrate deploy workflow to peaceiris/actions-gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,22 +1,39 @@
-on: push
-name: Deploy
+name: Deploy Hexo
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+
 jobs:
   build:
-    name: Build
+    name: Build & Deploy
     runs-on: ubuntu-latest
     steps:
-    - name: Clean
-      uses: heowc/action-hexo@main
-      with:
-        args: clean
-    - name: Generate
-      uses: heowc/action-hexo@main
-      with:
-        args: generate
-    - name: Deploy
-      uses: heowc/action-hexo@main
-      env:
-        EMAIL: longzk@2980.com
-        NAME: longzhaokun
-      with:
-        args: deploy
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Clean
+        run: npx hexo clean
+
+      - name: Generate
+        run: npx hexo generate
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          user_name: longzhaokun
+          user_email: longzk@2980.com

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## 环境要求
 
-- [Node.js](https://nodejs.org/) >= 12
+- [Node.js](https://nodejs.org/) >= 18（推荐 20）
 - [Git](https://git-scm.com/)
 
 ## 快速开始
@@ -73,34 +73,40 @@ hexo publish "文章标题"
 
 | 命令 | 说明 |
 |------|------|
-| `npm run server` | 启动本地预览服务器 |
+| `npm run server` | 启动本地预览服务器（http://localhost:4000） |
 | `npm run build` | 生成静态文件到 `public/` |
 | `npm run clean` | 清除缓存和生成的文件 |
-| `npm run deploy` | 部署到 GitHub Pages |
+| `npm run deploy` | 本地推送到 gh-pages（一般不用，CI 会做） |
 
-或使用 npx 直接调用：
+或使用 npx：
 
 ```bash
 npx hexo server       # 本地预览
 npx hexo generate     # 生成静态文件
 npx hexo clean        # 清理
-npx hexo deploy       # 部署
+npx hexo new "标题"   # 创建新文章
 ```
 
 ## 发布流程
 
-```bash
-# 1. 清理旧的生成文件
-npm run clean
+本项目**通过 GitHub Actions 自动部署**。当你把代码 `push` 到 `master` 分支，CI 会自动执行 `clean → generate → deploy`，将 `public/` 目录发布到 `gh-pages` 分支。
 
-# 2. 生成静态文件
+**首次部署需要配置**：仓库 Settings → Pages → Branch 选 `gh-pages` / `/ (root)`。
+
+**Workflow 文件**：`.github/workflows/deploy.yml`（使用 `peaceiris/actions-gh-pages@v4`）。
+
+### 本地调试
+
+```bash
+# 仅本地生成静态文件（用于预览）
+npm run clean
 npm run build
 
-# 3. 部署到 GitHub Pages
-npm run deploy
+# 本地预览服务器
+npm run server
 ```
 
-部署目标：`git@github.com:ZhaoKunLong/ZhaoKunLong.github.io.git` 的 `master` 分支。
+> 注：`npm run deploy` 也可以本地执行推送（依赖 `hexo-deployer-git`），但通常**不需要**——直接 push 触发 CI 即可。
 
 ## 目录结构
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "hexo": "^6.0.0",
+    "hexo-deployer-git": "^4.0.0",
     "hexo-generator-archive": "^2.0.0",
     "hexo-generator-category": "^1.0.0",
     "hexo-generator-feed": "^3.0.0",


### PR DESCRIPTION
The previous heowc/action-hexo@main action has been unmaintained since 2021-05-03 and is built on Node 12, causing CI failures with the current Hexo/Node versions.

Changes:
- Replace heowc/action-hexo with peaceiris/actions-gh-pages@v4
- Add explicit Node 20 setup and npm ci step
- Add hexo-deployer-git dependency for local deploy option
- Update README to document the CI-based deploy flow